### PR TITLE
no-unused-vars: remove (TODO) comment

### DIFF
--- a/typescript.json
+++ b/typescript.json
@@ -29,7 +29,6 @@
     "@typescript-eslint/no-empty-interface": [ "error", { "allowSingleExtends": true } ],
     "@typescript-eslint/no-this-alias": "error",
     // problematic in TypeScript / ES6
-    // why is there no native 'no-unused-vars'? (cf. termbox)
     "@typescript-eslint/no-unused-vars": [ "error", { "argsIgnorePattern": "^_" } ],
     "@typescript-eslint/no-useless-constructor": "error",
     "@typescript-eslint/prefer-function-type": "error",


### PR DESCRIPTION
Michael found the reason why a TODO comment was overly paranoid - we
inherit the right config.
https://github.com/typescript-eslint/typescript-eslint/blob/f5c0e021a2863aebf983bfd2f32861243f101b37/packages/eslint-plugin/src/configs/recommended.json#L25