### PR TITLE
npm: align version in package-lock with reality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wmde/eslint-config-wikimedia-typescript",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Was skipped in 53d93a6 apparently, became evident in https://github.com/wmde/eslint-config-wikimedia-typescript/pull/5