### PR TITLE
Bump major version of typescript eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "eslint-config-wikimedia": "^0.15.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.3.1",
-    "@typescript-eslint/parser": "^2.3.1",
+    "@typescript-eslint/eslint-plugin": "^3.1.0",
+    "@typescript-eslint/parser": "^3.1.0",
     "eslint-config-wikimedia": "^0.15.0"
   }
 }

--- a/typescript.json
+++ b/typescript.json
@@ -21,6 +21,7 @@
       "allowTypedFunctionExpressions": true,
       "allowHigherOrderFunctions": true
     } ],
+    "@typescript-eslint/explicit-module-boundary-types": ["error"],
     "@typescript-eslint/explicit-member-accessibility": [ "error", { "accessibility": "explicit" } ],
     // aligned to https://github.com/wikimedia/eslint-config-wikimedia/blob/master/common.json#L21
     "@typescript-eslint/indent": [ "error", "tab", { "SwitchCase": 1 } ],


### PR DESCRIPTION
This is obviously a breaking change. I wonder if we should make use of that opportunity and also bump `eslint-config-wikimedia` to [0.15.2](https://github.com/wikimedia/eslint-config-wikimedia/releases/tag/v0.15.2) which brings linting rules for `.vue` files among other things.

https://github.com/typescript-eslint/typescript-eslint/releases/tag/v3.0.0