### PR TITLE
Add member-delimiter-style

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -25,6 +25,7 @@ module.exports = {
     "@typescript-eslint/explicit-member-accessibility": [ "error", { "accessibility": "explicit" } ],
     // aligned to https://github.com/wikimedia/eslint-config-wikimedia/blob/master/common.json#L21
     "@typescript-eslint/indent": [ "error", "tab", { "SwitchCase": 1 } ],
+    "@typescript-eslint/member-delimiter-style": "error",
     "no-empty-function": "off",
     "@typescript-eslint/no-empty-function": "error",
     "@typescript-eslint/no-empty-interface": [ "error", { "allowSingleExtends": true } ],


### PR DESCRIPTION
[This rule][1] ensures a consistent style in interfaces and type literals: always use semicolons (not commas or only newlines), and include a final delimiter iff the type has multiple lines. (The rule is configurable, but the defaults seem fine for us, in my opinion.)

[1]: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/member-delimiter-style.md