### PR TITLE
Update dependencies to make new eslint-config-wikimedia available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
 			"version": "0.2.4",
 			"license": "GPL-2.0+",
 			"devDependencies": {
-				"eslint": "^8.8.0",
-				"eslint-config-wikimedia": "^0.23.0"
+				"eslint": "^8.36.0",
+				"eslint-config-wikimedia": "^0.24.0"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.6.0",
-				"@typescript-eslint/parser": "^5.6.0",
-				"eslint-config-wikimedia": "^0.23.0"
+				"@typescript-eslint/eslint-plugin": "^5.56.0",
+				"@typescript-eslint/parser": "^5.56.0",
+				"eslint-config-wikimedia": "^0.24.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -125,9 +125,9 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.2.tgz",
-			"integrity": "sha512-pM6WQKcuAtdYoqCsXSvVSu3Ij8K0HY50L8tIheOKHDl0wH1uA4zbP88etY8SIeP16NVCMCTFU+Q2DahSKheGGQ==",
+			"version": "0.23.6",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.23.6.tgz",
+			"integrity": "sha512-cCtumxG+qrYORGeOkDQ58GtSt/bb2XiP9GC0x2YduoUEX2EmBQ48FtoZMUs+8wiIdTDN1izUiRUD2FDu+p+Lvg==",
 			"dev": true,
 			"dependencies": {
 				"comment-parser": "1.3.1",
@@ -138,15 +138,37 @@
 				"node": "^12 || ^14 || ^16 || ^17"
 			}
 		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz",
+			"integrity": "sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==",
+			"dependencies": {
+				"eslint-visitor-keys": "^3.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
+			"integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+			"integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
-				"globals": "^13.15.0",
+				"espree": "^9.5.0",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -160,10 +182,18 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/js": {
+			"version": "8.36.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+			"integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.7",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
@@ -229,9 +259,9 @@
 			}
 		},
 		"node_modules/@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"peer": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -240,20 +270,27 @@
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
 		},
+		"node_modules/@types/semver": {
+			"version": "7.3.13",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+			"peer": true
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.11.0.tgz",
-			"integrity": "sha512-HJh33bgzXe6jGRocOj4FmefD7hRY4itgjzOrSs3JPrTNXsX7j5+nQPciAUj/1nZtwo2kAc3C75jZO+T23gzSGw==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz",
+			"integrity": "sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.11.0",
-				"@typescript-eslint/type-utils": "5.11.0",
-				"@typescript-eslint/utils": "5.11.0",
-				"debug": "^4.3.2",
-				"functional-red-black-tree": "^1.0.1",
-				"ignore": "^5.1.8",
-				"regexpp": "^3.2.0",
-				"semver": "^7.3.5",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@typescript-eslint/scope-manager": "5.56.0",
+				"@typescript-eslint/type-utils": "5.56.0",
+				"@typescript-eslint/utils": "5.56.0",
+				"debug": "^4.3.4",
+				"grapheme-splitter": "^1.0.4",
+				"ignore": "^5.2.0",
+				"natural-compare-lite": "^1.4.0",
+				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
 			},
 			"engines": {
@@ -273,16 +310,31 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/parser": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.11.0.tgz",
-			"integrity": "sha512-x0DCjetHZYBRovJdr3U0zG9OOdNXUaFLJ82ehr1AlkArljJuwEsgnud+Q7umlGDFLFrs8tU8ybQDFocp/eX8mQ==",
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.11.0",
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/typescript-estree": "5.11.0",
-				"debug": "^4.3.2"
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
+			"integrity": "sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "5.56.0",
+				"@typescript-eslint/types": "5.56.0",
+				"@typescript-eslint/typescript-estree": "5.56.0",
+				"debug": "^4.3.4"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -301,13 +353,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.11.0.tgz",
-			"integrity": "sha512-z+K4LlahDFVMww20t/0zcA7gq/NgOawaLuxgqGRVKS0PiZlCTIUtX0EJbC0BK1JtR4CelmkPK67zuCgpdlF4EA==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
+			"integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/visitor-keys": "5.11.0"
+				"@typescript-eslint/types": "5.56.0",
+				"@typescript-eslint/visitor-keys": "5.56.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -318,13 +370,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.11.0.tgz",
-			"integrity": "sha512-wDqdsYO6ofLaD4DsGZ0jGwxp4HrzD2YKulpEZXmgN3xo4BHJwf7kq49JTRpV0Gx6bxkSUmc9s0EIK1xPbFFpIA==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
+			"integrity": "sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.11.0",
-				"debug": "^4.3.2",
+				"@typescript-eslint/typescript-estree": "5.56.0",
+				"@typescript-eslint/utils": "5.56.0",
+				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
 			"engines": {
@@ -344,9 +397,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.11.0.tgz",
-			"integrity": "sha512-cxgBFGSRCoBEhvSVLkKw39+kMzUKHlJGVwwMbPcTZX3qEhuXhrjwaZXWMxVfxDgyMm+b5Q5b29Llo2yow8Y7xQ==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
+			"integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
 			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -357,17 +410,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.11.0.tgz",
-			"integrity": "sha512-yVH9hKIv3ZN3lw8m/Jy5I4oXO4ZBMqijcXCdA4mY8ull6TPTAoQnKKrcZ0HDXg7Bsl0Unwwx7jcXMuNZc0m4lg==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
+			"integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/visitor-keys": "5.11.0",
-				"debug": "^4.3.2",
-				"globby": "^11.0.4",
+				"@typescript-eslint/types": "5.56.0",
+				"@typescript-eslint/visitor-keys": "5.56.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.5",
+				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
 			},
 			"engines": {
@@ -383,18 +436,35 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/utils": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.11.0.tgz",
-			"integrity": "sha512-g2I480tFE1iYRDyMhxPAtLQ9HAn0jjBtipgTCZmd9I9s11OV8CTsG+YfFciuNDcHqm4csbAgC2aVZCHzLxMSUw==",
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"peer": true,
 			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
+			"integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
+			"peer": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.2.0",
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.11.0",
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/typescript-estree": "5.11.0",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.56.0",
+				"@typescript-eslint/types": "5.56.0",
+				"@typescript-eslint/typescript-estree": "5.56.0",
 				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"semver": "^7.3.7"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -407,14 +477,29 @@
 				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.11.0.tgz",
-			"integrity": "sha512-E8w/vJReMGuloGxJDkpPlGwhxocxOpSVgSvjiLO5IxZPmxZF30weOeJYyPSEACwM+X4NziYS9q+WkN/2DHYQwA==",
+		"node_modules/@typescript-eslint/utils/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.11.0",
-				"eslint-visitor-keys": "^3.0.0"
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
+			"integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/types": "5.56.0",
+				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -788,12 +873,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.26.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-			"integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+			"version": "8.36.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+			"integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
 			"dependencies": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@humanwhocodes/config-array": "^0.11.6",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@eslint/eslintrc": "^2.0.1",
+				"@eslint/js": "8.36.0",
+				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
@@ -803,16 +891,15 @@
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^7.1.1",
-				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"espree": "^9.5.0",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.15.0",
+				"globals": "^13.19.0",
 				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
@@ -827,7 +914,6 @@
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
-				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
@@ -843,16 +929,16 @@
 			}
 		},
 		"node_modules/eslint-config-wikimedia": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.23.0.tgz",
-			"integrity": "sha512-miZGPrfSZL9RcsSn8OSiQWZpeeMc3xCgIIimNWF6C+8Nfd38gb1FCdcgKQFC7HscFanMQL21DaPErMJVW+FB1Q==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.24.0.tgz",
+			"integrity": "sha512-8oH/YhJ87ONSmuRfATgx8U7Jcwz3tBemrh6YOezIfj9f2QfE71ZhaKZrNPdfS7vIklLor/cB9vX7sxN10nz8xw==",
 			"dev": true,
 			"dependencies": {
 				"browserslist-config-wikimedia": "^0.4.0",
-				"eslint": "^8.14.0",
+				"eslint": "^8.31.0",
 				"eslint-plugin-compat": "^4.0.2",
 				"eslint-plugin-es-x": "^5.2.1",
-				"eslint-plugin-jsdoc": "^38.1.6",
+				"eslint-plugin-jsdoc": "39.2.2",
 				"eslint-plugin-json-es": "^1.5.7",
 				"eslint-plugin-mediawiki": "^0.4.0",
 				"eslint-plugin-mocha": "^9.0.0",
@@ -907,25 +993,39 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "38.1.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz",
-			"integrity": "sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==",
+			"version": "39.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.2.tgz",
+			"integrity": "sha512-ybkvja0p9JRzHEd2ST9h+Z47DLOuPyXpeb6r18/zKHdMmggPU1J0/zl+F0phea8ze9rMxi42MJVmGXi2NZ7PpA==",
 			"dev": true,
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.22.1",
+				"@es-joy/jsdoccomment": "~0.23.1",
 				"comment-parser": "1.3.1",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
-				"regextras": "^0.8.0",
-				"semver": "^7.3.5",
+				"semver": "^7.3.7",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"engines": {
-				"node": "^12 || ^14 || ^16 || ^17"
+				"node": "^14 || ^16 || ^17"
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/eslint-plugin-json-es": {
@@ -1162,6 +1262,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
 			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dev": true,
 			"dependencies": {
 				"eslint-visitor-keys": "^2.0.0"
 			},
@@ -1179,6 +1280,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
 			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+			"dev": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -1212,9 +1314,9 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-			"integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+			"integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
@@ -1228,9 +1330,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -1288,9 +1390,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"peer": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1399,12 +1501,6 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"node_modules/functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-			"peer": true
-		},
 		"node_modules/glob": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -1436,9 +1532,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.17.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-			"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+			"version": "13.20.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -1745,13 +1841,13 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 			"peer": true,
 			"dependencies": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=8.6"
@@ -1786,6 +1882,12 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"node_modules/natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"peer": true
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.2",
@@ -2004,9 +2106,9 @@
 			}
 		},
 		"node_modules/punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -2151,20 +2253,12 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
-		"node_modules/regextras": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
-			"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.14"
 			}
 		},
 		"node_modules/requireindex": {
@@ -2259,6 +2353,7 @@
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
 			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -2692,9 +2787,9 @@
 			}
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.22.2",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.2.tgz",
-			"integrity": "sha512-pM6WQKcuAtdYoqCsXSvVSu3Ij8K0HY50L8tIheOKHDl0wH1uA4zbP88etY8SIeP16NVCMCTFU+Q2DahSKheGGQ==",
+			"version": "0.23.6",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.23.6.tgz",
+			"integrity": "sha512-cCtumxG+qrYORGeOkDQ58GtSt/bb2XiP9GC0x2YduoUEX2EmBQ48FtoZMUs+8wiIdTDN1izUiRUD2FDu+p+Lvg==",
 			"dev": true,
 			"requires": {
 				"comment-parser": "1.3.1",
@@ -2702,15 +2797,28 @@
 				"jsdoc-type-pratt-parser": "~2.2.5"
 			}
 		},
+		"@eslint-community/eslint-utils": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.3.0.tgz",
+			"integrity": "sha512-v3oplH6FYCULtFuCeqyuTd9D2WKO937Dxdq+GmHOLL72TTRriLxz2VLlNfkZRsvj6PKnOPAtuT6dwrs/pA5DvA==",
+			"requires": {
+				"eslint-visitor-keys": "^3.3.0"
+			}
+		},
+		"@eslint-community/regexpp": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
+			"integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw=="
+		},
 		"@eslint/eslintrc": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-			"integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
+			"integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.4.0",
-				"globals": "^13.15.0",
+				"espree": "^9.5.0",
+				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
@@ -2718,10 +2826,15 @@
 				"strip-json-comments": "^3.1.1"
 			}
 		},
+		"@eslint/js": {
+			"version": "8.36.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
+			"integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg=="
+		},
 		"@humanwhocodes/config-array": {
-			"version": "0.11.7",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-			"integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+			"version": "0.11.8",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
 			"requires": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
@@ -2768,9 +2881,9 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"peer": true
 		},
 		"@types/normalize-package-data": {
@@ -2779,99 +2892,142 @@
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
 			"dev": true
 		},
+		"@types/semver": {
+			"version": "7.3.13",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+			"peer": true
+		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.11.0.tgz",
-			"integrity": "sha512-HJh33bgzXe6jGRocOj4FmefD7hRY4itgjzOrSs3JPrTNXsX7j5+nQPciAUj/1nZtwo2kAc3C75jZO+T23gzSGw==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.56.0.tgz",
+			"integrity": "sha512-ZNW37Ccl3oMZkzxrYDUX4o7cnuPgU+YrcaYXzsRtLB16I1FR5SHMqga3zGsaSliZADCWo2v8qHWqAYIj8nWCCg==",
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.11.0",
-				"@typescript-eslint/type-utils": "5.11.0",
-				"@typescript-eslint/utils": "5.11.0",
-				"debug": "^4.3.2",
-				"functional-red-black-tree": "^1.0.1",
-				"ignore": "^5.1.8",
-				"regexpp": "^3.2.0",
-				"semver": "^7.3.5",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@typescript-eslint/scope-manager": "5.56.0",
+				"@typescript-eslint/type-utils": "5.56.0",
+				"@typescript-eslint/utils": "5.56.0",
+				"debug": "^4.3.4",
+				"grapheme-splitter": "^1.0.4",
+				"ignore": "^5.2.0",
+				"natural-compare-lite": "^1.4.0",
+				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"peer": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.11.0.tgz",
-			"integrity": "sha512-x0DCjetHZYBRovJdr3U0zG9OOdNXUaFLJ82ehr1AlkArljJuwEsgnud+Q7umlGDFLFrs8tU8ybQDFocp/eX8mQ==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.56.0.tgz",
+			"integrity": "sha512-sn1OZmBxUsgxMmR8a8U5QM/Wl+tyqlH//jTqCg8daTAmhAk26L2PFhcqPLlYBhYUJMZJK276qLXlHN3a83o2cg==",
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.11.0",
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/typescript-estree": "5.11.0",
-				"debug": "^4.3.2"
+				"@typescript-eslint/scope-manager": "5.56.0",
+				"@typescript-eslint/types": "5.56.0",
+				"@typescript-eslint/typescript-estree": "5.56.0",
+				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.11.0.tgz",
-			"integrity": "sha512-z+K4LlahDFVMww20t/0zcA7gq/NgOawaLuxgqGRVKS0PiZlCTIUtX0EJbC0BK1JtR4CelmkPK67zuCgpdlF4EA==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.56.0.tgz",
+			"integrity": "sha512-jGYKyt+iBakD0SA5Ww8vFqGpoV2asSjwt60Gl6YcO8ksQ8s2HlUEyHBMSa38bdLopYqGf7EYQMUIGdT/Luw+sw==",
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/visitor-keys": "5.11.0"
+				"@typescript-eslint/types": "5.56.0",
+				"@typescript-eslint/visitor-keys": "5.56.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.11.0.tgz",
-			"integrity": "sha512-wDqdsYO6ofLaD4DsGZ0jGwxp4HrzD2YKulpEZXmgN3xo4BHJwf7kq49JTRpV0Gx6bxkSUmc9s0EIK1xPbFFpIA==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
+			"integrity": "sha512-8WxgOgJjWRy6m4xg9KoSHPzBNZeQbGlQOH7l2QEhQID/+YseaFxg5J/DLwWSsi9Axj4e/cCiKx7PVzOq38tY4A==",
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.11.0",
-				"debug": "^4.3.2",
+				"@typescript-eslint/typescript-estree": "5.56.0",
+				"@typescript-eslint/utils": "5.56.0",
+				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.11.0.tgz",
-			"integrity": "sha512-cxgBFGSRCoBEhvSVLkKw39+kMzUKHlJGVwwMbPcTZX3qEhuXhrjwaZXWMxVfxDgyMm+b5Q5b29Llo2yow8Y7xQ==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.56.0.tgz",
+			"integrity": "sha512-JyAzbTJcIyhuUhogmiu+t79AkdnqgPUEsxMTMc/dCZczGMJQh1MK2wgrju++yMN6AWroVAy2jxyPcPr3SWCq5w==",
 			"peer": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.11.0.tgz",
-			"integrity": "sha512-yVH9hKIv3ZN3lw8m/Jy5I4oXO4ZBMqijcXCdA4mY8ull6TPTAoQnKKrcZ0HDXg7Bsl0Unwwx7jcXMuNZc0m4lg==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.56.0.tgz",
+			"integrity": "sha512-41CH/GncsLXOJi0jb74SnC7jVPWeVJ0pxQj8bOjH1h2O26jXN3YHKDT1ejkVz5YeTEQPeLCCRY0U2r68tfNOcg==",
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/visitor-keys": "5.11.0",
-				"debug": "^4.3.2",
-				"globby": "^11.0.4",
+				"@typescript-eslint/types": "5.56.0",
+				"@typescript-eslint/visitor-keys": "5.56.0",
+				"debug": "^4.3.4",
+				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
-				"semver": "^7.3.5",
+				"semver": "^7.3.7",
 				"tsutils": "^3.21.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"peer": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.11.0.tgz",
-			"integrity": "sha512-g2I480tFE1iYRDyMhxPAtLQ9HAn0jjBtipgTCZmd9I9s11OV8CTsG+YfFciuNDcHqm4csbAgC2aVZCHzLxMSUw==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.56.0.tgz",
+			"integrity": "sha512-XhZDVdLnUJNtbzaJeDSCIYaM+Tgr59gZGbFuELgF7m0IY03PlciidS7UQNKLE0+WpUTn1GlycEr6Ivb/afjbhA==",
 			"peer": true,
 			"requires": {
+				"@eslint-community/eslint-utils": "^4.2.0",
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.11.0",
-				"@typescript-eslint/types": "5.11.0",
-				"@typescript-eslint/typescript-estree": "5.11.0",
+				"@types/semver": "^7.3.12",
+				"@typescript-eslint/scope-manager": "5.56.0",
+				"@typescript-eslint/types": "5.56.0",
+				"@typescript-eslint/typescript-estree": "5.56.0",
 				"eslint-scope": "^5.1.1",
-				"eslint-utils": "^3.0.0"
+				"semver": "^7.3.7"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"peer": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.11.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.11.0.tgz",
-			"integrity": "sha512-E8w/vJReMGuloGxJDkpPlGwhxocxOpSVgSvjiLO5IxZPmxZF30weOeJYyPSEACwM+X4NziYS9q+WkN/2DHYQwA==",
+			"version": "5.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.56.0.tgz",
+			"integrity": "sha512-1mFdED7u5bZpX6Xxf5N9U2c18sb+8EvU3tyOIj6LQZ5OOvnmj8BVeNNP603OFPm5KkS1a7IvCIcwrdHXaEMG/Q==",
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.11.0",
-				"eslint-visitor-keys": "^3.0.0"
+				"@typescript-eslint/types": "5.56.0",
+				"eslint-visitor-keys": "^3.3.0"
 			}
 		},
 		"acorn": {
@@ -3137,12 +3293,15 @@
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 		},
 		"eslint": {
-			"version": "8.26.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-			"integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+			"version": "8.36.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
+			"integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
 			"requires": {
-				"@eslint/eslintrc": "^1.3.3",
-				"@humanwhocodes/config-array": "^0.11.6",
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.4.0",
+				"@eslint/eslintrc": "^2.0.1",
+				"@eslint/js": "8.36.0",
+				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"ajv": "^6.10.0",
@@ -3152,16 +3311,15 @@
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^7.1.1",
-				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"espree": "^9.5.0",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
-				"globals": "^13.15.0",
+				"globals": "^13.19.0",
 				"grapheme-splitter": "^1.0.4",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
@@ -3176,7 +3334,6 @@
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
-				"regexpp": "^3.2.0",
 				"strip-ansi": "^6.0.1",
 				"strip-json-comments": "^3.1.0",
 				"text-table": "^0.2.0"
@@ -3199,16 +3356,16 @@
 			}
 		},
 		"eslint-config-wikimedia": {
-			"version": "0.23.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.23.0.tgz",
-			"integrity": "sha512-miZGPrfSZL9RcsSn8OSiQWZpeeMc3xCgIIimNWF6C+8Nfd38gb1FCdcgKQFC7HscFanMQL21DaPErMJVW+FB1Q==",
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-wikimedia/-/eslint-config-wikimedia-0.24.0.tgz",
+			"integrity": "sha512-8oH/YhJ87ONSmuRfATgx8U7Jcwz3tBemrh6YOezIfj9f2QfE71ZhaKZrNPdfS7vIklLor/cB9vX7sxN10nz8xw==",
 			"dev": true,
 			"requires": {
 				"browserslist-config-wikimedia": "^0.4.0",
-				"eslint": "^8.14.0",
+				"eslint": "^8.31.0",
 				"eslint-plugin-compat": "^4.0.2",
 				"eslint-plugin-es-x": "^5.2.1",
-				"eslint-plugin-jsdoc": "^38.1.6",
+				"eslint-plugin-jsdoc": "39.2.2",
 				"eslint-plugin-json-es": "^1.5.7",
 				"eslint-plugin-mediawiki": "^0.4.0",
 				"eslint-plugin-mocha": "^9.0.0",
@@ -3248,19 +3405,29 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "38.1.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.1.6.tgz",
-			"integrity": "sha512-n4s95oYlg0L43Bs8C0dkzIldxYf8pLCutC/tCbjIdF7VDiobuzPI+HZn9Q0BvgOvgPNgh5n7CSStql25HUG4Tw==",
+			"version": "39.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.2.tgz",
+			"integrity": "sha512-ybkvja0p9JRzHEd2ST9h+Z47DLOuPyXpeb6r18/zKHdMmggPU1J0/zl+F0phea8ze9rMxi42MJVmGXi2NZ7PpA==",
 			"dev": true,
 			"requires": {
-				"@es-joy/jsdoccomment": "~0.22.1",
+				"@es-joy/jsdoccomment": "~0.23.1",
 				"comment-parser": "1.3.1",
 				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
-				"regextras": "^0.8.0",
-				"semver": "^7.3.5",
+				"semver": "^7.3.7",
 				"spdx-expression-parse": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.8",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+					"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"eslint-plugin-json-es": {
@@ -3425,6 +3592,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
 			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^2.0.0"
 			},
@@ -3432,7 +3600,8 @@
 				"eslint-visitor-keys": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
 				}
 			}
 		},
@@ -3442,9 +3611,9 @@
 			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
 		},
 		"espree": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-			"integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
+			"integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
 			"requires": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
@@ -3452,9 +3621,9 @@
 			}
 		},
 		"esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"requires": {
 				"estraverse": "^5.1.0"
 			},
@@ -3498,9 +3667,9 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"peer": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -3590,12 +3759,6 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"functional-red-black-tree": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-			"peer": true
-		},
 		"glob": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -3618,9 +3781,9 @@
 			}
 		},
 		"globals": {
-			"version": "13.17.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-			"integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+			"version": "13.20.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 			"requires": {
 				"type-fest": "^0.20.2"
 			}
@@ -3852,13 +4015,13 @@
 			"peer": true
 		},
 		"micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 			"peer": true,
 			"requires": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			}
 		},
 		"min-indent": {
@@ -3884,6 +4047,12 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"natural-compare-lite": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+			"integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+			"peer": true
 		},
 		"node-releases": {
 			"version": "2.0.2",
@@ -4044,9 +4213,9 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
 		},
 		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
@@ -4144,12 +4313,7 @@
 		"regexpp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
-		},
-		"regextras": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.8.0.tgz",
-			"integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
+			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
 		"requireindex": {
@@ -4208,6 +4372,7 @@
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
 			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
 		"typescript.json"
 	],
 	"devDependencies": {
-		"eslint": "^8.8.0",
-		"eslint-config-wikimedia": "^0.23.0"
+		"eslint": "^8.36.0",
+		"eslint-config-wikimedia": "^0.24.0"
 	},
 	"peerDependencies": {
-		"@typescript-eslint/eslint-plugin": "^5.6.0",
-		"@typescript-eslint/parser": "^5.6.0",
-		"eslint-config-wikimedia": "^0.23.0"
+		"@typescript-eslint/eslint-plugin": "^5.56.0",
+		"@typescript-eslint/parser": "^5.56.0",
+		"eslint-config-wikimedia": "^0.24.0"
 	}
 }


### PR DESCRIPTION
To be honest, I would also be fine with setting `"eslint-config-wikimedia": "*"` for the peer dependencies. I don't see how this hassle is worth it.

Also, I'm confused why we don't have dependabot on this repository. Here it would be actually really beneficial. I created #20 for that.

Bug: T332575