### PR TITLE
Have dependabot update also non-security package version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The main goal of this is dependabot updating the eslint-config-wikimedia peer dependency, so that we don't have to check this repo out and do it locally every time a new version of that is available.