### PR TITLE
Relax peer dependencies for eslint-plugin and parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@wmde/eslint-config-wikimedia-typescript",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@wmde/eslint-config-wikimedia-typescript",
-			"version": "0.2.10",
+			"version": "0.2.11",
 			"license": "GPL-2.0+",
 			"devDependencies": {
 				"eslint": "^8.57.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
 				"eslint-config-wikimedia": "^0.28.2"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "^8.0.1",
-				"@typescript-eslint/parser": "^8.0.1",
+				"@typescript-eslint/eslint-plugin": "8.x",
+				"@typescript-eslint/parser": "8.x",
 				"eslint-config-wikimedia": "^0.28.2"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/eslint-config-wikimedia-typescript",
-	"version": "0.2.10",
+	"version": "0.2.11",
 	"description": "ESLint config for TypeScript following Wikimedia code conventions.",
 	"main": "typescript.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
 		"eslint-config-wikimedia": "^0.28.2"
 	},
 	"peerDependencies": {
-		"@typescript-eslint/eslint-plugin": "^8.0.1",
-		"@typescript-eslint/parser": "^8.0.1",
+		"@typescript-eslint/eslint-plugin": "8.x",
+		"@typescript-eslint/parser": "8.x",
 		"eslint-config-wikimedia": "^0.28.2"
 	}
 }


### PR DESCRIPTION
We want to use a recent version of `eslint-plugin` and `parser`,
but we don't really care about the minor version here. In particular
there is a peer dependency conflict if both are set to 8.0.1 since
`eslint-plugin` at 8.0.1 has a peer dependency on `parser` at
exactly 8.0.0.

Relax the version requirement per the suggestion from the NPM docs
(https://nodejs.org/en/blog/npm/peer-dependencies) so that we can
accept a peer dependency of any version of the packages greater
than 8.

Bump the version so that we make a new release to NPM.