### PR TITLE
Relax peer dependency version requirement further, bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@wmde/eslint-config-wikimedia-typescript",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@wmde/eslint-config-wikimedia-typescript",
-			"version": "0.2.11",
+			"version": "0.2.12",
 			"license": "GPL-2.0+",
 			"devDependencies": {
 				"eslint": "^8.57.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
 				"eslint-config-wikimedia": "^0.28.2"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/eslint-plugin": "8.x",
-				"@typescript-eslint/parser": "8.x",
+				"@typescript-eslint/eslint-plugin": "^7.8.0 || ^8.0.0",
+				"@typescript-eslint/parser": "^7.8.0 || ^8.0.0",
 				"eslint-config-wikimedia": "^0.28.2"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
 		"eslint-config-wikimedia": "^0.28.2"
 	},
 	"peerDependencies": {
-		"@typescript-eslint/eslint-plugin": "8.x",
-		"@typescript-eslint/parser": "8.x",
+		"@typescript-eslint/eslint-plugin": "^7.8.0 || ^8.0.0",
+		"@typescript-eslint/parser": "^7.8.0 || ^8.0.0",
 		"eslint-config-wikimedia": "^0.28.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wmde/eslint-config-wikimedia-typescript",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"description": "ESLint config for TypeScript following Wikimedia code conventions.",
 	"main": "typescript.js",
 	"scripts": {


### PR DESCRIPTION
In some projects using eslint-config-wikimedia-typescript, there are
still some dependencies that pin `eslint-plugin` and `parser` to
`^7.0.0`. To support those packages while they transition over to
`^8.0.0`, relax the peer dependency again.

Bump the version to 0.2.12 so that we can install this in other
projects.